### PR TITLE
Replace `Base.n_waiters` with `isempty`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -170,7 +170,7 @@ end
 function Base.close(ch::OrderedChannel)
     @lock ch.cond begin
         # just need to ensure any tasks waiting to put their tasks have had a chance to put
-        while Base.n_waiters(ch.cond) > 0
+        while !isempty(ch.cond)
             wait(ch.cond)
         end
         close(ch.chan)


### PR DESCRIPTION
This PR follows from the suggestion by @inkydragon in https://github.com/JuliaLang/julia/pull/30089#issuecomment-948326768. No matter what the final decision in https://github.com/JuliaLang/julia/pull/30089 will be, I think that `!isempty(x)` is more readable than `length(x) > 0`.