### PR TITLE
Fix case where metadata is provided but empty

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -199,6 +199,7 @@ toidict(x::Base.ImmutableDict) = x
 
 # ref https://github.com/JuliaData/Arrow.jl/pull/238#issuecomment-919415809
 function toidict(pairs)
+    isempty(pairs) && return Base.ImmutableDict{String, String}()
     dict = Base.ImmutableDict(first(pairs))
     for pair in Iterators.drop(pairs, 1)
         dict = Base.ImmutableDict(dict, pair)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -488,6 +488,9 @@ t2 = (
 )
 @test_throws ArgumentError collect(Arrow.Stream([Arrow.tobuffer(t), Arrow.tobuffer(t2)]))
 
+# https://github.com/apache/arrow-julia/issues/253
+@test Arrow.toidict(Pair{String, String}[]) == Base.ImmutableDict{String, String}()
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #253. Just a simple fix to the `toidict` utility function to
account for the empty case. This would happen when metadata was
_provided_ for a table/column, but was empty, which would probably be a
common case in programmatic environments for reading/writing arrow.