### PR TITLE
disallow non-concrete map-like types to prevent incorrect serialization

### DIFF
--- a/src/arraytypes/map.jl
+++ b/src/arraytypes/map.jl
@@ -51,7 +51,10 @@ function arrowvector(::MapKind, x, i, nl, fi, de, ded, meta; largelists::Bool=fa
     validity = ValidityBitmap(x)
     ET = eltype(x)
     DT = Base.nonmissingtype(ET)
-    KT = KeyValue{keytype(DT), valtype(DT)}
+    KDT, VDT = keytype(DT), valtype(DT)
+    ArrowTypes.concrete_or_concreteunion(KDT) || throw(ArgumentError("`keytype(d)` must be concrete to serialize map-like `d`, but `keytype(d) == $KDT`"))
+    ArrowTypes.concrete_or_concreteunion(VDT) || throw(ArgumentError("`valtype(d)` must be concrete to serialize map-like `d`, but `valtype(d) == $VDT`"))
+    KT = KeyValue{KDT,VDT}
     VT = Vector{KT}
     T = DT !== ET ? Union{Missing, VT} : VT
     flat = ToList(T[keyvalues(KT, y) for y in x]; largelists=largelists)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -359,15 +359,14 @@ tbl = Arrow.Table(bytes)
 @test eltype(tbl.a) == Union{Int64, Missing}
 
 # 181
-tbl = (x = [Dict()],)
-d = tbl.x[];
-for i in 1:20
-    d[i] = Dict()
-    d = d[i]
+d = Dict{Int,Int}()
+for i in 1:9
+    d = Dict(i => d)
 end
-msg = "reached nested serialization level (42) deeper than provided max depth argument (41); to increase allowed nesting level, pass `maxdepth=X`"
-@test_throws ErrorException(msg) Arrow.tobuffer(tbl; maxdepth=41).x
-@test Arrow.Table(Arrow.tobuffer(tbl; maxdepth=42)).x == tbl.x
+tbl = (x = [d],)
+msg = "reached nested serialization level (20) deeper than provided max depth argument (19); to increase allowed nesting level, pass `maxdepth=X`"
+@test_throws ErrorException(msg) Arrow.tobuffer(tbl; maxdepth=19)
+@test Arrow.Table(Arrow.tobuffer(tbl; maxdepth=20)).x == tbl.x
 
 # 167
 t = (
@@ -490,6 +489,13 @@ t2 = (
 
 # https://github.com/apache/arrow-julia/issues/253
 @test Arrow.toidict(Pair{String, String}[]) == Base.ImmutableDict{String, String}()
+
+t = (; x=[Dict(true => 1.32, 1.2 => 0.53495216)])
+@test_throws ArgumentError("`keytype(d)` must be concrete to serialize map-like `d`, but `keytype(d) == Real`") Arrow.tobuffer(t)
+t = (; x=[Dict(32.0 => true, 1.2 => 0.53495216)])
+@test_throws ArgumentError("`valtype(d)` must be concrete to serialize map-like `d`, but `valtype(d) == Real`") Arrow.tobuffer(t)
+t = (; x=[Dict(true => 1.32, 1.2 => true)])
+@test_throws ArgumentError("`keytype(d)` must be concrete to serialize map-like `d`, but `keytype(d) == Real`") Arrow.tobuffer(t)
 
 end # @testset "misc"
 


### PR DESCRIPTION
Potential fix for #232, implements the simple check suggested by @quinnj in that thread.

This is technically breaking - the following works on `main` just fine, but will error after this PR due to the check:

```jl
julia> Arrow.Table(Arrow.tobuffer((; x = [Dict{Real,Real}(1 => 2)])))
Arrow.Table with 1 rows, 1 columns, and schema:
 :x  Dict{Int64, Int64}
```

IMO dropping support for nonconcrete keytypes/valtypes is preferable to the silent failure, but it would be good if we can have our cake and eat it too (which I think @quinnj 's other suggestion was referring to). 

@quinnj , when you mentioned:

> similar to what we do w/ arrays, we should probably try to enforce the Dict valtype with the concrete_or_concreteunion machinery in ArrowTypes.jl.

did you mean basically implementing a `Dict`-like version of https://github.com/apache/arrow-julia/blob/f88a62e0b6458ed6ea0439fc371f2e4ee0e039a7/src/ArrowTypes/src/ArrowTypes.jl#L336-L357, and wrapping incoming map-like values in that?

I can take a stab at that too, if so, but might not get time to do so this week; in that case, it might be worth folding this in earlier (since the silent failure mode here is pretty bad, IMO) and then recovering the functionality in a subsequent release. Up to you, though.

