### PR TITLE
add missing arrowtype(b, ::Type{<:Period}) method to enable roundtripping of Period types

### DIFF
--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -359,6 +359,8 @@ function arrowtype(b, ::Type{Duration{U}}) where {U}
     return Meta.Duration, Meta.durationEnd(b), nothing
 end
 
+arrowtype(b, ::Type{P}) where {P <: Dates.Period} = arrowtype(b, Duration{arrowperiodtype(P)})
+
 arrowperiodtype(P) = Meta.TimeUnits.SECOND
 arrowperiodtype(::Type{Dates.Millisecond}) = Meta.TimeUnits.MILLISECOND
 arrowperiodtype(::Type{Dates.Microsecond}) = Meta.TimeUnits.MICROSECOND

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -490,12 +490,24 @@ t2 = (
 # https://github.com/apache/arrow-julia/issues/253
 @test Arrow.toidict(Pair{String, String}[]) == Base.ImmutableDict{String, String}()
 
+# https://github.com/apache/arrow-julia/issues/232
 t = (; x=[Dict(true => 1.32, 1.2 => 0.53495216)])
 @test_throws ArgumentError("`keytype(d)` must be concrete to serialize map-like `d`, but `keytype(d) == Real`") Arrow.tobuffer(t)
 t = (; x=[Dict(32.0 => true, 1.2 => 0.53495216)])
 @test_throws ArgumentError("`valtype(d)` must be concrete to serialize map-like `d`, but `valtype(d) == Real`") Arrow.tobuffer(t)
 t = (; x=[Dict(true => 1.32, 1.2 => true)])
 @test_throws ArgumentError("`keytype(d)` must be concrete to serialize map-like `d`, but `keytype(d) == Real`") Arrow.tobuffer(t)
+
+# https://github.com/apache/arrow-julia/issues/214
+t1 = (; x = [(Nanosecond(42),)])
+t2 = Arrow.Table(Arrow.tobuffer(t1))
+t3 = Arrow.Table(Arrow.tobuffer(t2))
+@test t3.x == t1.x
+
+t1 = (; x = [(; a=Nanosecond(i), b=Nanosecond(i+1)) for i = 1:5])
+t2 = Arrow.Table(Arrow.tobuffer(t1))
+t3 = Arrow.Table(Arrow.tobuffer(t2))
+@test t3.x == t1.x
 
 end # @testset "misc"
 


### PR DESCRIPTION
fixes #214 

@quinnj This is a fairly localized fix that seems harmless + a strict improvement, but it might be worth double-checking I'm not missing the bigger picture here (i.e. confirm it's sensible that this method was reached at all via the roundtrip MWE).