### PR TITLE
Use a large RC number for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          RELEASE_DEFAULT=0 dev/release/release_rc.sh 1
+          RELEASE_DEFAULT=0 dev/release/release_rc.sh 100
       - uses: actions/cache@v1
         with:
           path: ~/.julia/artifacts
@@ -59,7 +59,7 @@ jobs:
           version=$(grep -o '^version = ".*"' "Project.toml" | \
                       sed -e 's/^version = "//g' \
                           -e 's/"$//g')
-          VERIFY_DEFAULT=0 dev/release/verify_rc.sh ${version} 1
+          VERIFY_DEFAULT=0 dev/release/verify_rc.sh ${version} 100
   test:
     name: ${{ matrix.pkg.name }} - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
fix #314

This is for avoiding verify release RC CI job failures with RC1
commit.