### PR TITLE
support reading empty files that are in the process of being written

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -527,6 +527,12 @@ t3 = Arrow.Table(Arrow.tobuffer(t2))
     @test table.b == collect(b)
 end
 
+# Empty input
+@test Arrow.Table(UInt8[]) isa Arrow.Table
+@test isempty(Tables.rows(Arrow.Table(UInt8[])))
+@test Arrow.Stream(UInt8[]) isa Arrow.Stream
+@test isempty(Tables.partitions(Arrow.Stream(UInt8[])))
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Currently trying to read an empty file that is in the process of being written throws an exception.  A cleaner way to handle this is to return an empty table/stream.