### PR TITLE
fix Julia 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,6 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-        exclude:
-          # Test Arrow.jl/ArrowTypes.jl on their oldest supported Julia versions
-          - pkg:
-              name: Arrow.jl
-            version: '1.6'
-          - pkg:
-              name: ArrowTypes.jl
-            version: '1.4'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -128,7 +128,7 @@ function arrowvector(::DictEncodedKind, x::DictEncoded, i, nl, fi, de, ded, meta
         de[id] = Lockable(x.encoding)
     else
         encodinglockable = de[id]
-        @lock encodinglockable begin
+        Base.@lock encodinglockable begin
             encoding = encodinglockable.value
             # in this case, we just need to check if any values in our local pool need to be delta dicationary serialized
             deltas = setdiff(x.encoding, encoding)
@@ -195,7 +195,7 @@ function arrowvector(::DictEncodedKind, x, i, nl, fi, de, ded, meta; dictencode:
           # if value doesn't exist in encoding, push! it
           # also add to deltas updates
         encodinglockable = de[id]
-        @lock encodinglockable begin
+        Base.@lock encodinglockable begin
             encoding = encodinglockable.value
             len = length(x)
             ET = indextype(encoding)


### PR DESCRIPTION
When I look at the CI jobs on the last commit on `main` it looks like Arrow tests aren't run against `1.6`, but the CI.yml looks like it does consider 1.6 - but it's also a more complex setup, I guess something may go wrong somewhere?
Anyways, the latest tagged version of Arrow.jl fails to compile on Julia 1.6...