### PR TITLE
Add `svn` as a release dependency

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -105,6 +105,7 @@ You must install the following commands to use the script:
   * `gpg`
   * `shasum` or `sha256sum`/`sha512sum`
   * `tar`
+  * `svn`
 
 You don't need to install Julia. If there isn't Julia in system, the latest Julia is automatically installed only for verification.
 


### PR DESCRIPTION
I get:
```
dev/release/release_rc.sh: line 80: svn: command not found
```