### PR TITLE
MINOR: Update issue notifications to issues mailing list to match Arrow repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@
 
 notifications:
   commits: commits@arrow.apache.org
-  issues: issues@arrow.apache.org
+  issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org
 


### PR DESCRIPTION
As suggested by @kou on this PR:
https://github.com/apache/arrow/pull/14811#discussion_r1037472268
This will match the configuration on the Arrow repository.