### PR TITLE
Define defaults for `Missing`/`Nothing`

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -304,7 +304,11 @@ default(::Type{Symbol}) = Symbol()
 default(::Type{Char}) = '\0'
 default(::Type{<:AbstractString}) = ""
 default(::Type{Any}) = nothing
+default(::Type{Missing}) = missing
+default(::Type{Nothing}) = nothing
 default(::Type{Union{T, Missing}}) where {T} = default(T)
+default(::Type{Union{T, Nothing}}) where {T} = default(T)
+default(::Type{Union{T, Missing, Nothing}}) where {T} = default(T)
 
 function default(::Type{A}) where {A <: AbstractVector{T}} where {T}
     a = similar(A, 1)

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -130,7 +130,11 @@ v_nt = (major=1, minor=0, patch=0, prerelease=(), build=())
 @test ArrowTypes.default(Symbol) == Symbol()
 @test ArrowTypes.default(Char) == '\0'
 @test ArrowTypes.default(String) == ""
+@test ArrowTypes.default(Missing) === missing
+@test ArrowTypes.default(Nothing) === nothing
 @test ArrowTypes.default(Union{Int, Missing}) == Int(0)
+@test ArrowTypes.default(Union{Int, Nothing}) == Int(0)
+@test ArrowTypes.default(Union{Int, Missing, Nothing}) == Int(0)
 
 @test ArrowTypes.promoteunion(Int, Float64) == Float64
 @test ArrowTypes.promoteunion(Int, String) == Union{Int, String}


### PR DESCRIPTION
Addresses the code failure in https://github.com/apache/arrow-julia/issues/368. Also pointed out in that issue is that `ArrowTypes.default` isn't documented in the manual. I can address that in another PR if that is something we should address.