### PR TITLE
Get dictionaries of children only when field.children not nothing 

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -384,8 +384,10 @@ function getdictionaries!(dictencoded, field)
     if d !== nothing
         dictencoded[d.id] = field
     end
-    for child in field.children
-        getdictionaries!(dictencoded, child)
+    if field.children !== nothing
+        for child in field.children
+            getdictionaries!(dictencoded, child)
+        end
     end
     return
 end


### PR DESCRIPTION
Closes #375 

This PR fixes a problem in reading an Arrow IPC file generated by C# Apache.Arrow 10.0.1 where the last recursive iteration to get the dictionaries returns `nothing` instead of an empty iterable.