### PR TITLE
Fix `ToArrow` when using an abstract `eltype` with all missing elements

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -349,7 +349,7 @@ function ToArrow(x::A) where {A}
         for i = 2:length(x)
             @inbounds T = promoteunion(T, typeof(toarrow(x[i])))
         end
-        if T === Missing
+        if T === Missing && concrete_or_concreteunion(S)
             T = promoteunion(T, typeof(toarrow(default(S))))
         end
     end

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -164,7 +164,7 @@ v_nt = (major=1, minor=0, patch=0, prerelease=(), build=())
     @test eltype(x) == Union{Float64, String}
     @test x == [1.0, 3.14, "hey"]
 
-    @testset "respect non-missing type" begin
+    @testset "respect non-missing concrete type" begin
         struct DateTimeTZ
             instant::Int64
             tz::String
@@ -186,6 +186,13 @@ v_nt = (major=1, minor=0, patch=0, prerelease=(), build=())
         # `ArrowTypes.toarrow(nothing) === missing`. Defining `toarrow(::Nothing) = nothing`
         # would break this test by returning `Union{Nothing,Missing}`.
         @test eltype(ArrowTypes.ToArrow(Any[missing])) == Missing
+    end
+
+    @testset "ignore non-missing abstract type" begin
+        x = ArrowTypes.ToArrow(Union{Missing,Array{Int}}[missing])
+        @test x isa ArrowTypes.ToArrow{Missing, Vector{Union{Missing, Array{Int64}}}}
+        @test eltype(x) == Missing
+        @test isequal(x, [missing])
     end
 end
 


### PR DESCRIPTION
Addresses an issue introduced in #371:

```julia
julia> ArrowTypes.ToArrow(Union{Missing, Array{Int}}[missing])
ERROR: MethodError: no method matching zero(::Type{Union{Missing, Array{Int64}}})
Closest candidates are:
  zero(::Type{Union{Missing, T}}) where T at missing.jl:105
  zero(::Union{Type{P}, P}) where P<:Dates.Period at ~/Development/Julia/aarch64/1.8/usr/share/julia/stdlib/v1.8/Dates/src/periods.jl:53
  zero(::LinearAlgebra.Diagonal) at ~/Development/Julia/aarch64/1.8/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/special.jl:381
  ...
Stacktrace:
 [1] default(T::Type)
   @ ArrowTypes ~/.julia/dev/Arrow/src/ArrowTypes/src/ArrowTypes.jl:303
 [2] ToArrow(x::Vector{Union{Missing, Array{Int64}}})
   @ ArrowTypes ~/.julia/dev/Arrow/src/ArrowTypes/src/ArrowTypes.jl:353
 [3] top-level scope
   @ REPL[2]:1
``` 

This error can occur when `eltype` of the array is non-concrete and all of the elements in the array are `missing`. 

The approach in #371 doesn't work well with abstract `eltype`s as it uses `ArrowTypes.default` (i.e. what instance would `ArrowTypes.default(Array{Int})` return?). So this PR restricts the solution from #371 to only concrete `eltype`s.