### PR TITLE
Revert "Tag new version dev/release/release.sh (#381)"

### DIFF
--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -28,12 +28,6 @@ fi
 version=$1
 rc=$2
 
-rc_tag="v${version}-rc${rc}"
-release_tag="v${version}"
-echo "Tagging for release: ${release_tag}"
-git tag -a -m "${version}" "${release_tag}" "${rc_tag}^{}"
-git push origin "${release_tag}"
-
 rc_id="apache-arrow-julia-${version}-rc${rc}"
 release_id="arrow-julia-${version}"
 echo "Move from dev/ to release/"


### PR DESCRIPTION
This reverts commit 59a6a10dadf5c2a3228c079e78b354a31a3f7973.

Because the TagBot works.

See also: https://github.com/apache/arrow-julia/issues/387#issuecomment-1416763917