### PR TITLE
do not instantiate new Vector when calling fromarrow

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -220,8 +220,7 @@ _symbol(ptr, len) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), ptr, len
 fromarrow(::Type{Symbol}, ptr::Ptr{UInt8}, len::Int) = _symbol(ptr, len)
 
 ArrowKind(::Type{<:AbstractArray}) = ListKind()
-fromarrow(::Type{A}, x::A) where {A <: AbstractVector{T}} where {T} = x
-fromarrow(::Type{A}, x::AbstractVector{T}) where {A <: AbstractVector{T}} where {T} = convert(A, x)
+fromarrow(::Type{A}, x::AbstractVector{T}) where {T, A <: AbstractVector{T}} = x
 ArrowKind(::Type{<:AbstractSet}) = ListKind()
 ArrowType(::Type{T}) where {T <: AbstractSet{S}} where {S} = Vector{S}
 toarrow(x::AbstractSet) = collect(x)


### PR DESCRIPTION
Currently when there's a table containing a column of type variable-size list, whenever the user accesses an entry in the list a new Vector is instantiated causing allocations and performance degradation.  This PR proposes to prevent instantiating the Vector and instead return to the user a zero-copy view of the data (SubArray) that still abides by the AbstractVector interface.

For example, instead of getting a newly-allocated `Vector{Int64}`:

```julia
julia> using Arrow, Tables

julia> x = (a=[1,2,3], b=[[1,1,1], [2,2], [3,3,3,3]]);

julia> table = Arrow.Table(Arrow.tobuffer(x))
Arrow.Table with 3 rows, 2 columns, and schema:
:a  Int64
:b  Vector{Int64} (alias for Array{Int64, 1})

julia> p = iterate(Tables.rows(table))
(Tables.ColumnsRow{Tables.CopiedColumns{Arrow.Table}}: (a = 1, b = [1, 1, 1]), 2)

julia> p[1].b
3-element Vector{Int64}:
1
1
1
```

we'll instead get a `SubArray`:

```julia
julia> using Arrow, Tables

julia> x = (a=[1,2,3], b=[[1,1,1], [2,2], [3,3,3,3]]);

julia> table = Arrow.Table(Arrow.tobuffer(x))
Arrow.Table with 3 rows, 2 columns, and schema:
:a  Int64
:b  Vector{Int64} (alias for Array{Int64, 1})

julia> p = iterate(Tables.rows(table))
(Tables.ColumnsRow{Tables.CopiedColumns{Arrow.Table}}: (a = 1, b = [1, 1, 1]), 2)

julia> p[1].b
3-element view(::Arrow.Primitive{Int64, Vector{Int64}}, 1:3) with eltype Int64:
1
1
1
```