### PR TITLE
enable incremental reads of arrow-formatted files

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -73,21 +73,11 @@ end
 # count # of missing elements in an iterable
 nullcount(col) = count(ismissing, col)
 
-# like startswith/endswith for strings, but on byte buffers
+# like startswith for strings, but on byte buffers
 function _startswith(a::AbstractVector{UInt8}, pos::Integer, b::AbstractVector{UInt8})
     for i = 1:length(b)
         @inbounds check = a[pos + i - 1] == b[i]
         check || return false
-    end
-    return true
-end
-
-function _endswith(a::AbstractVector{UInt8}, endpos::Integer, b::AbstractVector{UInt8})
-    aoff = endpos - length(b) + 1
-    for i = 1:length(b)
-        @inbounds check = a[aoff] == b[i]
-        check || return false
-        aoff += 1
     end
     return true
 end

--- a/src/write.jl
+++ b/src/write.jl
@@ -189,7 +189,7 @@ function write(writer::Writer, source)
         if !isassigned(writer.firstcols)
             if writer.writetofile
                 @debugv 1 "starting write of arrow formatted file"
-                Base.write(writer.io, "ARROW1\0\0")
+                Base.write(writer.io, FILE_FORMAT_MAGIC_BYTES, b"\0\0")
             end
             meta = isnothing(writer.meta) ? getmetadata(source) : writer.meta
             cols = toarrowtable(tblcols, writer.dictencodings, writer.largelists, writer.compress, writer.denseunions, writer.dictencode, writer.dictencodenested, writer.maxdepth, meta, writer.colmeta)
@@ -358,7 +358,7 @@ function Base.write(io::IO, msg::Message, blocks, sch, alignment)
     end
     # now write the final message spec out
     # continuation byte
-    n = Base.write(io, 0xFFFFFFFF)
+    n = Base.write(io, CONTINUATION_INDICATOR_BYTES)
     # metadata length
     n += Base.write(io, Int32(metalen))
     # message flatbuffer


### PR DESCRIPTION
This allows users to read Arrow files while they're being written even when not using IPC mode.  This is accomplished by removing the requirement that the data must end with the magic "ARROW1".