### PR TITLE
Use `getproperty` instead of type parameter to get names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,7 @@ julia = "1.6"
 
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -61,4 +62,4 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "FilePathsBase", "JSON3", "Random", "StructTypes", "TOML", "Test"]
+test = ["CategoricalArrays", "DataFrames",  "FilePathsBase", "JSON3", "Random", "StructTypes", "TOML", "Test"]

--- a/src/write.jl
+++ b/src/write.jl
@@ -388,8 +388,9 @@ function makemessage(b, headerType, header, columns=nothing, bodylen=0)
     return Message(FlatBuffers.finishedbytes(b), columns, bodylen, headerType == Meta.RecordBatch, headerType == Meta.RecordBatch || headerType == Meta.DictionaryBatch, headerType)
 end
 
-function makeschema(b, sch::Tables.Schema{names}, columns) where {names}
+function makeschema(b, sch::Tables.Schema, columns)
     # build Field objects
+    names = sch.names
     N = length(names)
     fieldoffsets = [fieldoffset(b, names[i], columns.cols[i]) for i = 1:N]
     Meta.schemaStartFieldsVector(b, N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -574,13 +574,11 @@ end
 
 # https://github.com/apache/arrow-julia/issues/414
 df = DataFrame(("$i" => rand(1000) for i in 1:65536)...)
-Arrow.write("df.arrow", df)
-df_load = Arrow.Table("df.arrow")
+df_load = Arrow.Table(Arrow.tobuffer(df))
 @test Tables.schema(df) == Tables.schema(df_load)
 for (col1, col2) in zip(Tables.columns(df), Tables.columns(df_load))
     @test col1 == col2
 end
-rm("df.arrow")
 
 
 end # @testset "misc"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 using Test, Arrow, ArrowTypes, Tables, Dates, PooledArrays, TimeZones, UUIDs,
-    CategoricalArrays, DataAPI, FilePathsBase
+    CategoricalArrays, DataAPI, FilePathsBase, DataFrames
 using Random: randstring
 
 # Compat shim for pre-julia 1.9
@@ -571,6 +571,17 @@ if pkgversion(ArrowTypes) >= v"2.0.2"
     @test Tables.schema(a) == Tables.schema(t)
     @test isequal(a.x, t.x)
 end
+
+# https://github.com/apache/arrow-julia/issues/414
+df = DataFrame(("$i" => rand(1000) for i in 1:65536)...)
+Arrow.write("df.arrow", df)
+df_load = Arrow.Table("df.arrow")
+@test Tables.schema(df) == Tables.schema(df_load)
+for (col1, col2) in zip(Tables.columns(df), Tables.columns(df_load))
+    @test col1 == col2
+end
+rm("df.arrow")
+
 
 end # @testset "misc"
 


### PR DESCRIPTION
Closes #414 

`Tables.Schema` does not store names in the type parameters if there are more than `(2^16) - 1` columns: 

https://github.com/JuliaData/Tables.jl/blob/2cb13998e856692ed273c931b83477caf8b7b020/src/Tables.jl#L477-L483