### PR TITLE
Bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"


### PR DESCRIPTION
This is to get #415 released to allow writing wide (more than 65535 columns) tables to Arrow.

@kou, could you take it from here?