### PR TITLE
Add Tables.partitions definition for Arrow.Table

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -674,6 +674,19 @@ t = Arrow.Table(joinpath(dirname(pathof(Arrow)), "../test/java_compress_len_neg_
 
 end
 
+@testset "# 293" begin
+
+t = (a = [1, 2, 3], b = [1.0, 2.0, 3.0])
+buf = Arrow.tobuffer(t)
+tbl = Arrow.Table(buf)
+parts = Tables.partitioner((t, t))
+buf2 = Arrow.tobuffer(parts)
+tbl2 = Arrow.Table(buf2)
+for t in Tables.partitions(tbl2)
+    @test t.a == tbl.a
+    @test t.b == tbl.b
+end
+
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -687,6 +687,8 @@ for t in Tables.partitions(tbl2)
     @test t.b == tbl.b
 end
 
+end
+
 end # @testset "misc"
 
 end

--- a/test/testappend.jl
+++ b/test/testappend.jl
@@ -129,12 +129,13 @@ function testappend_partitions()
         arrow_table2 = Arrow.Table(file2)
         # now
         # arrow_table1: 2 partitions, 20 rows
-        # arrow_table2: 2 partitions, 30 rows (both partitions of table1 are appended as single partition)
+        # arrow_table2: 2 partitions, 30 rows (both partitions of table1 are appended as separate partitions)
 
         @test Tables.schema(arrow_table1) == Tables.schema(arrow_table2)
         @test length(Tables.columns(arrow_table1)[1]) == 20
         @test length(Tables.columns(arrow_table2)[1]) == 30
-        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == length(collect(Tables.partitions(Arrow.Stream(file2))))
+        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == 2
+        @test length(collect(Tables.partitions(Arrow.Stream(file2)))) == 3
 
         Arrow.append(file1, Arrow.Stream(file2))
         arrow_table1 = Arrow.Table(file1)
@@ -145,6 +146,7 @@ function testappend_partitions()
         @test Tables.schema(arrow_table1) == Tables.schema(arrow_table2)
         @test length(Tables.columns(arrow_table1)[1]) == 50
         @test length(Tables.columns(arrow_table2)[1]) == 30
-        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == 2 * length(collect(Tables.partitions(Arrow.Stream(file2))))
+        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == 5
+        @test length(collect(Tables.partitions(Arrow.Stream(file2)))) == 3
     end
 end


### PR DESCRIPTION
We had this functionality w/ `Arrow.Stream`, but it's convenient and not that expensive to define it for `Arrow.Table` as well.

Fixes #293.