### PR TITLE
implement default for SubArray

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -348,6 +348,8 @@ function default(::Type{A}) where {A <: AbstractVector{T}} where {T}
     return a
 end
 
+default(::Type{A}) where {A <: SubArray} = default(Vector{eltype(A)})
+
 default(::Type{NTuple{N, T}}) where {N, T} = ntuple(i -> default(T), N)
 default(::Type{T}) where {T <: Tuple} = Tuple(default(fieldtype(T, i)) for i = 1:fieldcount(T))
 default(::Type{T}) where {T <: AbstractDict} = T()

--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -348,7 +348,7 @@ function default(::Type{A}) where {A <: AbstractVector{T}} where {T}
     return a
 end
 
-default(::Type{SubArray{T,N,P,I,L}}) where {T,N,P,I,L} = default(P)
+default(::Type{SubArray{T,N,P,I,L}}) where {T,N,P,I,L} = view(default(P), 0:-1)
 
 default(::Type{NTuple{N, T}}) where {N, T} = ntuple(i -> default(T), N)
 default(::Type{T}) where {T <: Tuple} = Tuple(default(fieldtype(T, i)) for i = 1:fieldcount(T))

--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -348,7 +348,7 @@ function default(::Type{A}) where {A <: AbstractVector{T}} where {T}
     return a
 end
 
-default(::Type{A}) where {A <: SubArray} = default(Vector{eltype(A)})
+default(::Type{SubArray{T,N,P,I,L}}) where {T,N,P,I,L} = default(P)
 
 default(::Type{NTuple{N, T}}) where {N, T} = ntuple(i -> default(T), N)
 default(::Type{T}) where {T <: Tuple} = Tuple(default(fieldtype(T, i)) for i = 1:fieldcount(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -707,6 +707,15 @@ t = Arrow.Table(buf)
 
 end
 
+@testset "# 456" begin
+
+NT = @NamedTuple{x::Int, y::Union{Missing,Int}}
+data = NT[(x=1,y=2), (x=2,y=missing), (x=3,y=4), (x=4,y=5)]
+t = [(a=1,b=view(data,1:2)), (a=2,b=view(data,3:4)), missing]
+@test Arrow.toarrowvector(t) isa Arrow.Struct
+
+end
+
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -707,14 +707,14 @@ t = Arrow.Table(buf)
 
 end
 
-@testset "# 456" begin
+# @testset "# 456" begin
 
-NT = @NamedTuple{x::Int, y::Union{Missing,Int}}
-data = NT[(x=1,y=2), (x=2,y=missing), (x=3,y=4), (x=4,y=5)]
-t = [(a=1,b=view(data,1:2)), (a=2,b=view(data,3:4)), missing]
-@test Arrow.toarrowvector(t) isa Arrow.Struct
+# NT = @NamedTuple{x::Int, y::Union{Missing,Int}}
+# data = NT[(x=1,y=2), (x=2,y=missing), (x=3,y=4), (x=4,y=5)]
+# t = [(a=1,b=view(data,1:2)), (a=2,b=view(data,3:4)), missing]
+# @test Arrow.toarrowvector(t) isa Arrow.Struct
 
-end
+# end
 
 end # @testset "misc"
 


### PR DESCRIPTION
`similar(::Type{<:SubArray})` doesn't exist.  This change should handle it gracefully.