### PR TITLE
Fix case of recursively nested lists

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -650,7 +650,7 @@ function build(f::Meta.Field, L::ListTypes, batch, rb, de, nodeidx, bufferidx, c
         # juliaeltype returns Vector for List, translate to SubArray
         S = Base.nonmissingtype(T)
         if S <: Vector
-            ST = SubVector{eltype(S), typeof(A)}
+            ST = SubVector{eltype(A), typeof(A)}
             T = S == T ? ST : Union{Missing, ST}
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -698,6 +698,15 @@ t = Arrow.Table(joinpath(dirname(pathof(Arrow)), "../test/java_compressed_zero_l
 
 end
 
+@testset "# 458" begin
+
+x = (; a=[[[[1]]]])
+buf = Arrow.tobuffer(x)
+t = Arrow.Table(buf)
+@test t.a[1][1][1][1] == 1
+
+end
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes issue reported by @Moelf in #458.

The issue is we need to get the eltype from the recursively built child array instead of as a top-level translation of the current field type.