### PR TITLE
Ensure that ArrowTypes.default is defined for Vararg tuples

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -351,7 +351,13 @@ end
 default(::Type{SubArray{T,N,P,I,L}}) where {T,N,P,I,L} = view(default(P), 0:-1)
 
 default(::Type{NTuple{N, T}}) where {N, T} = ntuple(i -> default(T), N)
-default(::Type{T}) where {T <: Tuple} = Tuple(default(fieldtype(T, i)) for i = 1:fieldcount(T))
+default(::Type{Tuple{}}) = ()
+function default(::Type{T}) where {T <: Tuple}
+    T === Tuple{} && return ()
+    N = Base.isvarargtype(T.parameters[end]) ? length(T.parameters) - 1 : fieldcount(T)
+    return Tuple(default(fieldtype(T, i)) for i = 1:N)
+end
+
 default(::Type{T}) where {T <: AbstractDict} = T()
 default(::Type{NamedTuple{names, types}}) where {names, types} = NamedTuple{names}(Tuple(default(fieldtype(types, i)) for i = 1:length(names)))
 

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -137,6 +137,10 @@ nt = (id=1, name="bob")
 @test ArrowTypes.JuliaType(Val(ArrowTypes.TUPLE), NamedTuple{(Symbol("1"), Symbol("2")), Tuple{Int, String}}) == Tuple{Int, String}
 @test ArrowTypes.fromarrow(Tuple{Int, String}, nt) == (1, "bob")
 @test ArrowTypes.fromarrow(Union{Missing, typeof(nt)}, nt) == nt
+# #461
+@test ArrowTypes.default(Tuple{}) == ()
+@test ArrowTypes.default(Tuple{Vararg{Int}}) == ()
+@test ArrowTypes.default(Tuple{String, Vararg{Int}}) == ("",)
 
 v = v"1"
 v_nt = (major=1, minor=0, patch=0, prerelease=(), build=())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -713,6 +713,15 @@ t = [(a=1,b=view(data,1:2)), (a=2,b=view(data,3:4)), missing]
 
 end
 
+# @testset "# 461" begin
+
+# table = (; v=[v"1", v"2", missing])
+# buf = Arrow.tobuffer(table)
+# table2 = Arrow.Table(buf)
+# @test isequal(table.v, table2.v)
+
+# end
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #461. This is the other proposal from what I originally suggested. Though `Tuple{Varag}` is never the concrete type of a value in Julia, it comes up when dealing with structs with fields that have Vararg types; not common at all, but it's allowed and happens.

The reflection code here is a little gross, but it seems to be what Base Julia uses in similar queries to see if a tuple has a vararg element. I've commented out the Arrow/runtests test for now until we bump another version and can then uncomment. Unit tests are added for ArrowTypes in the meantime.