### PR TITLE
Use https://arrow.apache.org/julia/ as the official document URL

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,7 +25,7 @@ notifications:
 
 github:
   description: "Official Julia implementation of Apache Arrow"
-  homepage: https://arrow.apache.org/
+  homepage: https://arrow.apache.org/julia/
   labels:
     - apache-arrow
     - julia

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # Arrow
 
-[![docs](https://img.shields.io/badge/docs-latest-blue&logo=julia)](https://arrow.apache.org/julia/dev/)
+[![docs](https://img.shields.io/badge/docs-latest-blue&logo=julia)](https://arrow.apache.org/julia/)
 [![CI](https://github.com/apache/arrow-julia/workflows/CI/badge.svg)](https://github.com/apache/arrow-julia/actions?query=workflow%3ACI)
 [![codecov](https://app.codecov.io/gh/apache/arrow-julia/branch/main/graph/badge.svg)](https://app.codecov.io/gh/apache/arrow-julia)
 
@@ -68,4 +68,4 @@ Third-party data formats:
   * Other Tables.jl-compatible packages automatically supported ([DataFrames.jl](https://github.com/JuliaData/DataFrames.jl), [JSONTables.jl](https://github.com/JuliaData/JSONTables.jl), [JuliaDB.jl](https://github.com/JuliaData/JuliaDB.jl), [SQLite.jl](https://github.com/JuliaDatabases/SQLite.jl), [MySQL.jl](https://github.com/JuliaDatabases/MySQL.jl), [JDBC.jl](https://github.com/JuliaDatabases/JDBC.jl), [ODBC.jl](https://github.com/JuliaDatabases/ODBC.jl), [XLSX.jl](https://github.com/felipenoris/XLSX.jl), etc.)
   * No current Julia packages support ORC
 
-See the [full documentation](https://arrow.apache.org/julia/dev/) for details on reading and writing arrow data.
+See the [full documentation](https://arrow.apache.org/julia/) for details on reading and writing arrow data.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,7 @@ makedocs(;
     sitename="Arrow.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://arrow.juliadata.org/",
+        canonical="https://arrow.apache.org/julia/",
         assets=String[],
     ),
     pages=[


### PR DESCRIPTION
fix #470