### PR TITLE
improved support for struct columns with missing values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.7.1"
+version = "2.7.2"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"


### PR DESCRIPTION
The current implementation depends on `Arrow.default` returning a sentinel object when the value is missing.  This usually works, but occasionally has problems.  This PR simplifies the implementation and solves some of the problematic corner-cases.

One example of a problematic corner-case is a column of lists of structs:

```julia
julia> [(a=1,b=2), missing, (a=3,b=4)]
3-element Vector{Union{Missing, @NamedTuple{a::Int64, b::Int64}}}:
 (a = 1, b = 2)
 missing
 (a = 3, b = 4)
```

It's possible that users may wrap this Vector in a `SubArray`.  In this case `Arrow.default(::Type{<:SubArray })` actually uses `Arrow.default(::Type{<:AbstractVector})` which enforces that the parent-type is a `Vector` - this is not always the case.  For example, the parent may well be of type `Arrow.Struct` if the data being written was also read from an Arrow file.  Certainly we could enhance `Arrow.default` to return a proper type for SubArray but simpler is to remove the dependency on `Arrow.default` from `ToStruct`.