### PR TITLE
migrate ArrowTypes code that depends on Sockets and UUIDs to extensions

### DIFF
--- a/src/ArrowTypes/Project.toml
+++ b/src/ArrowTypes/Project.toml
@@ -18,7 +18,7 @@
 name = "ArrowTypes"
 uuid = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 

--- a/src/ArrowTypes/Project.toml
+++ b/src/ArrowTypes/Project.toml
@@ -21,8 +21,14 @@ authors = ["quinnj <quinn.jacobd@gmail.com>"]
 version = "2.3.0"
 
 [deps]
+
+[weakdeps]
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
+[extensions]
+ArrowTypesSocketsExt = "Sockets"
+ArrowTypesUUIDsExt = "UUIDs"
+
 [compat]
-julia = "1.0"
+julia = "1.9"

--- a/src/ArrowTypes/ext/ArrowTypesSocketsExt.jl
+++ b/src/ArrowTypes/ext/ArrowTypesSocketsExt.jl
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module ArrowTypesSocketsExt
+
+import ArrowTypes
+import Sockets: IPv4, IPv6, IPAddr, InetAddr
+
+ArrowTypes.ArrowKind(::Type{IPv4}) = ArrowTypes.PrimitiveKind()
+ArrowTypes.ArrowType(::Type{IPv4}) = UInt32
+ArrowTypes.toarrow(x::IPv4) = x.host
+const IPV4_SYMBOL = Symbol("JuliaLang.IPv4")
+ArrowTypes.arrowname(::Type{IPv4}) = IPV4_SYMBOL
+ArrowTypes.JuliaType(::Val{IPV4_SYMBOL}) = IPv4
+ArrowTypes.fromarrow(::Type{IPv4}, x::Integer) = IPv4(x)
+
+ArrowTypes.ArrowKind(::Type{IPv6}) = ArrowTypes.FixedSizeListKind{16,UInt8}()
+ArrowTypes.ArrowType(::Type{IPv6}) = NTuple{16,UInt8}
+ArrowTypes.toarrow(x::IPv6) = reinterpret(NTuple{16,UInt8}, x.host)
+const IPV6_SYMBOL = Symbol("JuliaLang.IPv6")
+ArrowTypes.arrowname(::Type{IPv6}) = IPV6_SYMBOL
+ArrowTypes.JuliaType(::Val{IPV6_SYMBOL}) = IPv6
+ArrowTypes.fromarrow(::Type{IPv6}, x::NTuple{16,UInt8}) = IPv6(reinterpret(UInt128, x))
+
+const INET_ADDR_SYMBOL = Symbol("JuliaLang.InetAddr")
+ArrowTypes.arrowname(::Type{<:InetAddr}) = INET_ADDR_SYMBOL
+ArrowTypes.JuliaType(
+    ::Val{INET_ADDR_SYMBOL},
+    ::Type{@NamedTuple{host::T, port::UInt16}},
+) where {T<:IPAddr} = InetAddr{T}
+
+end # module ArrowTypesSocketsExt

--- a/src/ArrowTypes/ext/ArrowTypesUUIDsExt.jl
+++ b/src/ArrowTypes/ext/ArrowTypesUUIDsExt.jl
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module ArrowTypesUUIDsExt
+
+import ArrowTypes
+import UUIDs: UUID
+
+ArrowTypes.ArrowKind(::Type{UUID}) = ArrowTypes.FixedSizeListKind{16,UInt8}()
+ArrowTypes.ArrowType(::Type{UUID}) = NTuple{16,UInt8}
+ArrowTypes.toarrow(x::UUID) = reinterpret(NTuple{16,UInt8}, x.value)
+const UUID_SYMBOL = Symbol("JuliaLang.UUID")
+ArrowTypes.arrowname(::Type{UUID}) = UUID_SYMBOL
+ArrowTypes.JuliaType(::Val{UUID_SYMBOL}) = UUID
+ArrowTypes.fromarrow(::Type{UUID}, x::NTuple{16,UInt8}) = UUID(reinterpret(UInt128, x))
+
+end # module ArrowTypesUUIDsExt

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -100,30 +100,44 @@ end
     @test K == ArrowTypes.FixedSizeListKind{3,UInt8}()
 
     u = UUID(rand(UInt128))
-    ubytes = ArrowTypes._cast(NTuple{16,UInt8}, u.value)
+    ubytes = reinterpret(NTuple{16,UInt8}, u.value)
     @test ArrowTypes.ArrowKind(u) == ArrowTypes.FixedSizeListKind{16,UInt8}()
     @test ArrowTypes.ArrowType(UUID) == NTuple{16,UInt8}
     @test ArrowTypes.toarrow(u) == ubytes
-    @test ArrowTypes.arrowname(UUID) == ArrowTypes.UUIDSYMBOL
-    @test ArrowTypes.JuliaType(Val(ArrowTypes.UUIDSYMBOL)) == UUID
+    UUID_SYMBOL = Symbol("JuliaLang.UUID")
+    @test ArrowTypes.arrowname(UUID) == UUID_SYMBOL
+    @test ArrowTypes.JuliaType(Val(UUID_SYMBOL)) == UUID
     @test ArrowTypes.fromarrow(UUID, ubytes) == u
 
     ip4 = IPv4(rand(UInt32))
     @test ArrowTypes.ArrowKind(ip4) == PrimitiveKind()
     @test ArrowTypes.ArrowType(IPv4) == UInt32
     @test ArrowTypes.toarrow(ip4) == ip4.host
-    @test ArrowTypes.arrowname(IPv4) == ArrowTypes.IPV4_SYMBOL
-    @test ArrowTypes.JuliaType(Val(ArrowTypes.IPV4_SYMBOL)) == IPv4
+    IPV4_SYMBOL = Symbol("JuliaLang.IPv4")
+    @test ArrowTypes.arrowname(IPv4) == IPV4_SYMBOL
+    @test ArrowTypes.JuliaType(Val(IPV4_SYMBOL)) == IPv4
     @test ArrowTypes.fromarrow(IPv4, ip4.host) == ip4
 
     ip6 = IPv6(rand(UInt128))
-    ip6_ubytes = ArrowTypes._cast(NTuple{16,UInt8}, ip6.host)
+    ip6_ubytes = reinterpret(NTuple{16,UInt8}, ip6.host)
     @test ArrowTypes.ArrowKind(ip6) == ArrowTypes.FixedSizeListKind{16,UInt8}()
     @test ArrowTypes.ArrowType(IPv6) == NTuple{16,UInt8}
     @test ArrowTypes.toarrow(ip6) == ip6_ubytes
-    @test ArrowTypes.arrowname(IPv6) == ArrowTypes.IPV6_SYMBOL
-    @test ArrowTypes.JuliaType(Val(ArrowTypes.IPV6_SYMBOL)) == IPv6
+    IPV6_SYMBOL = Symbol("JuliaLang.IPv6")
+    @test ArrowTypes.arrowname(IPv6) == IPV6_SYMBOL
+    @test ArrowTypes.JuliaType(Val(IPV6_SYMBOL)) == IPv6
     @test ArrowTypes.fromarrow(IPv6, ip6_ubytes) == ip6
+
+    INET_ADDR_SYMBOL = Symbol("JuliaLang.InetAddr")
+    @test ArrowTypes.arrowname(Sockets.InetAddr{IPv4}) == INET_ADDR_SYMBOL
+    @test ArrowTypes.JuliaType(
+        Val(INET_ADDR_SYMBOL),
+        @NamedTuple{host::IPv4, port::UInt16},
+    ) == Sockets.InetAddr{IPv4}
+    @test ArrowTypes.JuliaType(
+        Val(INET_ADDR_SYMBOL),
+        @NamedTuple{host::IPv6, port::UInt16},
+    ) == Sockets.InetAddr{IPv6}
 
     nt = (id=1, name="bob")
     @test ArrowTypes.ArrowKind(NamedTuple) == ArrowTypes.StructKind()


### PR DESCRIPTION
Also add support for `Sockets.InetAddr`