### PR TITLE
Compatibility of schemas with nested types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.7.1"
+version = "2.7.2"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1047,12 +1047,12 @@ end
             struct Foo504
                 x::Int
             end
-            
+
             struct Bar504
                 a::Foo504
             end
 
-            v = [Bar504(Foo504(i)) for i =1:3]
+            v = [Bar504(Foo504(i)) for i = 1:3]
             io = IOBuffer()
             Arrow.write(io, v; file=false)
             seekstart(io)
@@ -1061,6 +1061,5 @@ end
             t = Arrow.Table(io)
             @test Arrow.Tables.rowcount(t) == 6
         end
-
     end # @testset "misc"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1043,16 +1043,16 @@ end
             end
         end
 
-        @testset "# tbd" begin
-            struct A
+        @testset "# 504" begin
+            struct Foo504
                 x::Int
             end
             
-            struct B
-                a::A
+            struct Bar504
+                a::Foo504
             end
 
-            v = [B(A(i)) for i =1:3]
+            v = [Bar504(Foo504(i)) for i =1:3]
             io = IOBuffer()
             Arrow.write(io, v; file=false)
             seekstart(io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1042,5 +1042,25 @@ end
                 @test tbl.f[2] === Foo493(4, 5)
             end
         end
+
+        @testset "# tbd" begin
+            struct A
+                x::Int
+            end
+            
+            struct B
+                a::A
+            end
+
+            v = [B(A(i)) for i =1:3]
+            io = IOBuffer()
+            Arrow.write(io, v; file=false)
+            seekstart(io)
+            Arrow.append(io, v) # testing the compatility between the schema of the arrow Table, and the "schema" of v (using the fallback mechanism of Tables.jl)
+            seekstart(io)
+            t = Arrow.Table(io)
+            @test Arrow.Tables.rowcount(t) == 6
+        end
+
     end # @testset "misc"
 end


### PR DESCRIPTION
Hi,

Here is a minimal example of the issue I've encountered.

```julia
 struct A
    x::Int
end

struct B
    a::A
end

v = [B(A(i)) for i =1:3]

io = IOBuffer()
Arrow.write(io, v; file=false)
seekstart(io)
Arrow.append(io, v) # throws
```

I don't know if this is really necessary, or if I'm not using this library properly, but this issue makes it difficult to append to arrow files with nested types.

Since I've only added more cases where the call to `append` can succeed, I do not think that this creates retro-compatibility issues.

Thanks for the review!