### PR TITLE
release: Fix "Verify release" job on macOS GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
           - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install julia subversion
       - name: Create
         run: |
           git config user.name "github-actions[bot]"

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -111,7 +111,7 @@ latest_julia_version() {
     --location \
     --show-error \
     --silent \
-    https://api.github.com/repos/JuliaLang/julia/releases | \
+    https://api.github.com/repos/JuliaLang/julia/releases/latest | \
     grep -o '"tag_name": "v.*"' | \
     head -n 1 | \
     sed -e 's/^"tag_name": "v//g' \
@@ -132,12 +132,11 @@ ensure_julia() {
     Darwin)
       julia_binary_url+="/mac"
       case "$(arch)" in
-        # TODO
-        # aarch64)
-        #   julia_binary_url+="/aarch64"
-        #   julia_binary_url+="/${julia_version_series}"
-        #   julia_binary_url+="/julia-${julia_version}-macaarch64.dmg"
-        #   ;;
+        arm64)
+          julia_binary_url+="/aarch64"
+          julia_binary_url+="/${julia_version_series}"
+          julia_binary_url+="/julia-${julia_version}-macaarch64.tar.gz"
+          ;;
         i386)
           julia_binary_url+="/x64"
           julia_binary_url+="/${julia_version_series}"


### PR DESCRIPTION
fixes #513

* Install Subversion explicitly
  * Because recent macOS GitHub Actions runner doesn't provide Subversion by default
* Add support for installing Julia for macOS (Apple Silicon)
  * Because the current `macos-latest` is macOS (Apple Silicon) 