### PR TITLE
Recommend using package-specific prefix with `arrowname`

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -109,11 +109,12 @@ end
 
 # overload interface method for custom type Person; return a symbol as the "name"
 # this instructs Arrow.write what "label" to include with a column with this custom type
-ArrowTypes.arrowname(::Type{Person}) = :Person
-# overload JuliaType on `Val{:Person}`, which is like a dispatchable string
+const NAME = Symbol("JuliaLang.MyPackage.Person")
+ArrowTypes.arrowname(::Type{Person}) = NAME
+# overload JuliaType on `Val{NAME}`, which is like a dispatchable string
 # return our custom *type* Person; this enables Arrow.Table to know how the "label"
 # on a custom column should be mapped to a Julia type and deserialized
-ArrowTypes.JuliaType(::Val{:Person}) = Person
+ArrowTypes.JuliaType(::Val{NAME}) = Person
 
 table = (col1=[Person(1, "Bob"), Person(2, "Jane")],)
 io = IOBuffer()
@@ -160,7 +161,7 @@ using Intervals
 table = (col = [
     Interval{Closed,Unbounded}(1,nothing),
 ],)
-const NAME = Symbol("JuliaLang.Interval")
+const NAME = Symbol("JuliaLang.Intervals.Interval")
 ArrowTypes.arrowname(::Type{Interval{T, L, R}}) where {T, L, R} = NAME
 const LOOKUP = Dict(
     "Closed" => Closed,

--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -100,9 +100,9 @@ toarrow(x) = x
     ArrowTypes.arrowname(T) = Symbol(name)
 
 Interface method to define the logical type "label" for a custom Julia type `T`. Names will be global for an entire arrow dataset,
-and conventionally, custom types will just use their type name along with a Julia-specific prefix; for example, for a custom type
-`Foo`, I would define `ArrowTypes.arrowname(::Type{Foo}) = Symbol("JuliaLang.Foo")`. This ensures other language implementations
-won't get confused and are safe to ignore the logical type label.
+and conventionally, custom types will just use their type name along with a Julia- and package-specific prefix; for example,
+for a custom type `Foo`, I would define `ArrowTypes.arrowname(::Type{Foo}) = Symbol("JuliaLang.MyPackage.Foo")`.
+This ensures other language implementations won't get confused and are safe to ignore the logical type label.
 When arrow stores non-native data, it must still be _stored_ as a native data type, but can have type metadata tied to the data that
 labels the original _logical_ type it originated from. This enables the conversion of native data back to the logical type when
 deserializing, as long as the deserializer has the same definitions when the data was serialized. Namely, the current Julia


### PR DESCRIPTION
Otherwise types may clash across packages. Only Julia Base types can avoid the second part of the prefix without risks.