### PR TITLE
Avoid extending `Type` from Base on Julia 1.12

### DIFF
--- a/src/metadata/Schema.jl
+++ b/src/metadata/Schema.jl
@@ -486,6 +486,11 @@ Base.propertynames(x::LargeListView) = ()
 largeListViewStart(b::FlatBuffers.Builder) = FlatBuffers.startobject!(b, 0)
 largeListViewEnd(b::FlatBuffers.Builder) = FlatBuffers.endobject!(b)
 
+# Ensure this binding is distinct from `Base.Type` by forward-declaring it. Otherwise, in
+# Julia 1.12, defining a function called `Type` by simply defining methods ends up actually
+# defining methods for `Base.Type`.
+function Type end
+
 function Type(b::UInt8)
     b == 1 && return Null
     b == 2 && return Int


### PR DESCRIPTION
The internal Flatbuf module defines a function called `Type`. On Julia 1.12, defining a new function by defining methods is insufficient to distinguish it from defining new constructor methods for a visible type of the same name. It's now necessary to forward-declare the function to ensure it takes precedence over the other visible binding. Without doing so, `Base.Type` is extended in Flatbuf instead.

On current `main` with Julia v1.13.0-DEV.122:
```julia-repl
julia> using Arrow
Info Given Arrow was explicitly requested, output will be shown live
WARNING: Constructor for type "Type" was extended in `Flatbuf` without explicit qualification or import.
  NOTE: Assumed "Type" refers to `Base.Type`. This behavior is deprecated and may differ in future versions.
  NOTE: This behavior may have differed in Julia versions prior to 1.12.
  Hint: If you intended to create a new generic function of the same name, use `function Type end`.
  Hint: To silence the warning, qualify `Type` as `Base.Type` in the method signature or explicitly `import Base: Type`.
Precompiling Arrow finished.
  1 dependency successfully precompiled in 4 seconds. 47 already precompiled.
  1 dependency had output during precompilation:
┌ Arrow
│  [Output was shown above]
└

julia> methods(Type)
# 2 methods for type constructor:
 [1] Type(b::UInt8)
     @ Arrow.Flatbuf ~/Projects/julia-packages/arrow-julia/src/metadata/Schema.jl:489
 [2] Type(::Type{T}) where T
     @ Arrow.Flatbuf ~/Projects/julia-packages/arrow-julia/src/metadata/Schema.jl:519

julia> Arrow.Flatbuf.Type === Type
[ Warning: Type is defined in Core and is not public in Arrow.Flatbuf
true
```
With this PR, the output is the same because of https://github.com/JuliaLang/julia/issues/57546 but will have the correct behavior once that issue is fixed.

Fixes #555