### PR TITLE
Remove duplicated notifications

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,12 +17,6 @@
 
 # https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
 
-notifications:
-  commits: commits@arrow.apache.org
-  issues_status: issues@arrow.apache.org
-  issues_comment: github@arrow.apache.org
-  pullrequests: github@arrow.apache.org
-
 github:
   description: "Official Julia implementation of Apache Arrow"
   homepage: https://arrow.apache.org/julia/


### PR DESCRIPTION
Sorry! I did messed up. I did miss the notifications on the top of the file (we have them at the bottom at the rest of the repos) and replicated the section.

This failed to apply the change for discussions as it had incorrect format.