### PR TITLE
Add support for running CI on fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,11 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
-    tags: ['*']
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
 jobs:
   license:
     name: Audit licenses


### PR DESCRIPTION
Fixes #552

Push for all branches except branches that are created by Dependabot runs CI. Dependabot creates a branch in apache/arrow-julia and open a PR to apache/arrow-juila. If it happens, CI is triggered by both of push and pull_request. We need only pull_request for the case.